### PR TITLE
Investigate premature battle end bug

### DIFF
--- a/app.py
+++ b/app.py
@@ -317,13 +317,17 @@ class GameState:
     
     def _end_round(self):
         """End current round and start new one"""
-        self.round_number += 1
+        # Log completion of the round that just finished
         self._log(f"Round {self.round_number} completed.")
-        
+
+        # If we've just finished the final round, end the battle
         if self.round_number >= self.max_rounds:
             self.game_running = False
             self._log("Battle finished!")
             return
+
+        # Increment round counter for the next round
+        self.round_number += 1
         
         # Reset tanks for new round
         for tank in self.tanks.values():


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Restructure `_end_round` logic to ensure all configured game rounds are played.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, `round_number` was incremented before checking against `max_rounds`, causing the battle to end prematurely after the second-to-last round. The logic is now reordered to check the current round number against `max_rounds` before incrementing, ensuring the final round is played.

---
<a href="https://cursor.com/background-agent?bcId=bc-e73d1965-c45d-43d3-80a5-a522d857bd1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e73d1965-c45d-43d3-80a5-a522d857bd1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>