### PR TITLE
Add bot taunt functionality to battle log

### DIFF
--- a/app.py
+++ b/app.py
@@ -329,6 +329,14 @@ class GameState:
             # Add bullets to global bullet list
             self.bullets.extend(tank.bullets)
             tank.bullets = []
+
+        # Taunt – allow tanks to send a battle-cry to the log
+        if 'taunt' in action:
+            taunt_msg = str(action['taunt'])
+            # Record in central battle log (capped inside _log)
+            self._log(f"{tank.name} shouts: {taunt_msg}")
+            # Also add to the tank's individual debug log for completeness
+            tank._add_debug_event('taunt', message=taunt_msg)
     
     def _check_collisions(self):
         """Check for bullet-tank collisions"""

--- a/tests/test_taunt.py
+++ b/tests/test_taunt.py
@@ -1,0 +1,39 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import GameState
+
+
+def test_taunt_action_logs_message():
+    gs = GameState()
+    gs.add_tank("Alpha", "#ff0000")
+    tank = gs.tanks["Alpha"]
+
+    # Execute taunt action directly
+    gs._execute_tank_action(tank, {"taunt": "Charge!"})
+
+    # The latest log message should contain the taunt
+    assert gs.logs[-1]["message"] == "Alpha shouts: Charge!"
+
+
+def test_taunt_via_brain_module():
+    gs = GameState()
+
+    brain_code = """
+
+def think(game_state):
+    # Always taunt
+    return {'taunt': 'For glory!'}
+"""
+    gs.add_tank("Taunter", "#00ff00", brain_code)
+
+    # Need at least one more tank to start game/update without ending immediately
+    gs.add_tank("Opponent", "#0000ff")
+
+    # Start the game and run one update frame
+    gs.start_game()
+    gs.update()
+
+    # Verify the taunt was logged
+    assert any("Taunter shouts: For glory!" == entry["message"] for entry in gs.logs), "Taunt message not found in logs"


### PR DESCRIPTION
Add a 'taunt' action for bots to print messages to the battle log.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a1d529e-5432-470b-afa2-6b938ebc77d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1a1d529e-5432-470b-afa2-6b938ebc77d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>