### PR TITLE
Show temporary taunts above user

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ ROTATION_SPEED = 3
 MAX_HEALTH = 100
 DAMAGE_PER_HIT = 25
 DEBUG_LOG_LIMIT = 200  # Max debug events to keep per tank
+TAUNT_DURATION = 2  # Seconds a taunt should remain visible
 
 # List of safe phonetic names for default tank names
 PHONETIC_NAMES = [
@@ -66,6 +67,9 @@ class Tank:
         self.score = 0
         self.kills = 0
         self.debug_log = []  # Store recent debug events for this tank
+        # Taunt handling
+        self.taunt: Optional[str] = None
+        self.taunt_timestamp: float = 0.0
         
     def _add_debug_event(self, event_type: str, **data):
         """Internal: append a debug event keeping list capped"""
@@ -153,7 +157,8 @@ class Tank:
             'alive': self.alive,
             'score': self.score,
             'kills': self.kills,
-            'debug': self.debug_log[-100:]
+            'debug': self.debug_log[-100:],
+            'taunt': self.taunt
         }
 
 class GameState:
@@ -219,6 +224,12 @@ class GameState:
         """Update game state for one frame"""
         if not self.game_running:
             return
+
+        # Clear expired taunts
+        now = time.time()
+        for t in self.tanks.values():
+            if t.taunt and now - t.taunt_timestamp > TAUNT_DURATION:
+                t.taunt = None
         
         # Update bullets
         self._update_bullets()
@@ -339,6 +350,14 @@ class GameState:
         if 'rotate' in action:
             tank.rotate(action['rotate'] * ROTATION_SPEED)
         
+        # Taunting
+        if 'taunt' in action and isinstance(action['taunt'], str):
+            taunt_text = action['taunt'][:50]  # Limit taunt length
+            tank.taunt = taunt_text
+            tank.taunt_timestamp = time.time()
+            tank._add_debug_event('taunt', text=taunt_text)
+            self._log(f"{tank.name} taunts: {taunt_text}")
+
         # Shooting
         if action.get('shoot', False):
             tank.shoot()

--- a/templates/index.html
+++ b/templates/index.html
@@ -135,6 +135,18 @@
             z-index: 50; /* ensure on top */
         }
 
+        .tank-taunt {
+            position: absolute;
+            font-size: 10px;
+            font-weight: bold;
+            background: rgba(0,0,0,0.6);
+            padding: 2px 4px;
+            border-radius: 4px;
+            transform: translateX(-50%);
+            white-space: nowrap;
+            z-index: 60;
+        }
+
         .game-info {
             display: flex;
             justify-content: space-between;
@@ -679,7 +691,7 @@ def think(game_state):
             loadingMessage.style.display = 'none';
             
             // Clear arena
-            const existingElements = arena.querySelectorAll('.tank, .bullet, .health-bar, .tank-name');
+            const existingElements = arena.querySelectorAll('.tank, .bullet, .health-bar, .tank-name, .tank-taunt');
             existingElements.forEach(el => el.remove());
             
             // Draw tanks
@@ -721,6 +733,16 @@ def think(game_state):
                 
                 arena.appendChild(healthBar);
                 arena.appendChild(tankName);
+
+                // Taunt (if any)
+                if (tank.taunt) {
+                    const tauntDiv = document.createElement('div');
+                    tauntDiv.className = 'tank-taunt';
+                    tauntDiv.textContent = tank.taunt;
+                    tauntDiv.style.left = tank.x + 'px';
+                    tauntDiv.style.top = (tank.y - 55) + 'px';
+                    arena.appendChild(tauntDiv);
+                }
             });
             
             // Draw bullets


### PR DESCRIPTION
Add functionality to display taunt messages above tanks for a short duration.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc376ebe-baf8-41c5-94dc-2f0598624042">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cc376ebe-baf8-41c5-94dc-2f0598624042">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>